### PR TITLE
feat: optimize _index_query performance in OceanBase Oracle mode

### DIFF
--- a/oceanbase-sqlalchemy-plugin/oceanbase_sqlalchemy/cx_oracle.py
+++ b/oceanbase-sqlalchemy-plugin/oceanbase_sqlalchemy/cx_oracle.py
@@ -207,3 +207,7 @@ class OceanBaseDialect_cx_oracle(OracleDialect_cx_oracle):
                 dictionary.all_ind_columns.c.column_position,
             )
         )
+
+
+# Register dialect, similar to SQLAlchemy's cx_oracle.py
+dialect = OceanBaseDialect_cx_oracle


### PR DESCRIPTION
## 🚀 Feature Description

Optimize the performance of `_index_query` method in OceanBase Oracle mode by adding early filtering conditions to reduce data scanning.

## 🎯 Optimization Details

- Override `_index_query` method in `OceanBaseDialect_cx_oracle` class
- Add filtering condition on `all_ind_columns.table_name`
- Filter data early in query execution to avoid full table scan

## 🔧 Technical Implementation

### Key Optimization
```python
# Added in WHERE clause:
dictionary.all_ind_columns.c.table_name.in_(bindparam("all_objects"))
```

### SQL Query Optimization
**Before**:
```sql
WHERE a_indexes.table_owner = :owner 
  AND a_indexes.table_name IN (:all_objects)
```

**After**:
```sql
WHERE a_indexes.table_owner = :owner 
  AND a_indexes.table_name IN (:all_objects)
  AND a_ind_columns.table_name IN (:all_objects)  -- New optimization condition
```

## 📈 Performance Benefits

- ✅ Reduces data scanning on `all_ind_columns` table
- ✅ Filters target table data early in query execution
- ✅ Avoids full table scan, significantly improving query performance
- ✅ Particularly beneficial for databases with large numbers of indexes

## 🧪 Testing & Validation

- ✅ Created and ran test script to verify optimization is effective
- ✅ Confirmed generated SQL contains optimization conditions
- ✅ Compatible with SQLAlchemy 2.x version

## 📝 Compatibility

- Only supports SQLAlchemy 2.x version
- Version control through `SA_20_PLUS` flag
- No impact on existing functionality

## 🔗 Related Files

- `oceanbase-sqlalchemy-plugin/oceanbase_sqlalchemy/cx_oracle.py`