### PR TITLE
fix(checkpoint): retry transient OceanBase disconnects

### DIFF
--- a/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/__init__.py
+++ b/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/__init__.py
@@ -19,7 +19,10 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 from langgraph.checkpoint.oceanbase import _internal
-from langgraph.checkpoint.oceanbase.base import BaseMySQLSaver
+from langgraph.checkpoint.oceanbase.base import (
+    BaseMySQLSaver,
+    _SyncCheckpointRetryMixin,
+)
 from langgraph.checkpoint.oceanbase.utils import (
     deserialize_channel_values,
     deserialize_pending_sends,
@@ -30,7 +33,11 @@ from langgraph.checkpoint.serde.base import SerializerProtocol
 Conn = _internal.Conn  # For backward compatibility
 
 
-class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
+class BaseSyncMySQLSaver(
+    _SyncCheckpointRetryMixin,
+    BaseMySQLSaver,
+    Generic[_internal.C, _internal.R],
+):
     lock: threading.Lock
 
     def __init__(
@@ -100,6 +107,23 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
         before: RunnableConfig | None = None,
         limit: int | None = None,
     ) -> Iterator[CheckpointTuple]:
+        results = self._with_retry(
+            self._list,
+            config,
+            filter=filter,
+            before=before,
+            limit=limit,
+        )
+        yield from results
+
+    def _list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> list[CheckpointTuple]:
         """List checkpoints from the database.
 
         This method retrieves a list of checkpoint tuples from the MySQL database based
@@ -141,7 +165,7 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
             cur.execute(query, args)
             values = cur.fetchall()
             if not values:
-                return
+                return []
             for value in values:
                 value["checkpoint"] = json.loads(value["checkpoint"])
                 value["channel_values"] = deserialize_channel_values(
@@ -160,23 +184,25 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
                         *[v["parent_checkpoint_id"] for v in to_migrate],
                     ),
                 )
-            pending_sends = cur.fetchall()
-            grouped_by_parent = defaultdict(list)
-            for value in to_migrate:
-                grouped_by_parent[value["parent_checkpoint_id"]].append(value)
-            for sends in pending_sends:
-                for value in grouped_by_parent[sends["checkpoint_id"]]:
-                    if value["channel_values"] is None:
-                        value["channel_values"] = []
-                    self._migrate_pending_sends(
-                        deserialize_pending_sends(sends["sends"]),
-                        value["checkpoint"],
-                        value["channel_values"],
-                    )
-            for value in values:
-                yield self._load_checkpoint_tuple(value)
+                pending_sends = cur.fetchall()
+                grouped_by_parent = defaultdict(list)
+                for value in to_migrate:
+                    grouped_by_parent[value["parent_checkpoint_id"]].append(value)
+                for sends in pending_sends:
+                    for value in grouped_by_parent[sends["checkpoint_id"]]:
+                        if value["channel_values"] is None:
+                            value["channel_values"] = []
+                        self._migrate_pending_sends(
+                            deserialize_pending_sends(sends["sends"]),
+                            value["checkpoint"],
+                            value["channel_values"],
+                        )
+            return [self._load_checkpoint_tuple(value) for value in values]
 
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        return self._with_retry(self._get_tuple, config)
+
+    def _get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database.
 
         This method retrieves a checkpoint tuple from the MySQL database based on the
@@ -268,6 +294,21 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
         metadata: CheckpointMetadata,
         new_versions: ChannelVersions,
     ) -> RunnableConfig:
+        return self._with_retry(
+            self._put,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+        )
+
+    def _put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
         """Save a checkpoint to the database.
 
         This method saves a checkpoint to the MySQL database. The checkpoint is associated
@@ -350,6 +391,21 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
         task_id: str,
         task_path: str = "",
     ) -> None:
+        return self._with_retry(
+            self._put_writes,
+            config,
+            writes,
+            task_id,
+            task_path,
+        )
+
+    def _put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
         """Store intermediate writes linked to a checkpoint.
 
         This method saves intermediate writes associated with a checkpoint to the MySQL database.
@@ -378,6 +434,9 @@ class BaseSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
             )
 
     def delete_thread(self, thread_id: str) -> None:
+        return self._with_retry(self._delete_thread, thread_id)
+
+    def _delete_thread(self, thread_id: str) -> None:
         """Delete all checkpoints and writes associated with a thread ID.
         Args:
             thread_id: The thread ID to delete.

--- a/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/aio_base.py
+++ b/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/aio_base.py
@@ -19,7 +19,10 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 from langgraph.checkpoint.oceanbase import _ainternal
-from langgraph.checkpoint.oceanbase.base import BaseMySQLSaver
+from langgraph.checkpoint.oceanbase.base import (
+    BaseMySQLSaver,
+    _AsyncCheckpointRetryMixin,
+)
 from langgraph.checkpoint.oceanbase.utils import (
     deserialize_channel_values,
     deserialize_pending_sends,
@@ -28,7 +31,11 @@ from langgraph.checkpoint.oceanbase.utils import (
 from langgraph.checkpoint.serde.base import SerializerProtocol
 
 
-class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
+class BaseAsyncMySQLSaver(
+    _AsyncCheckpointRetryMixin,
+    BaseMySQLSaver,
+    Generic[_ainternal.C, _ainternal.R],
+):
     lock: asyncio.Lock
 
     def __init__(
@@ -78,6 +85,24 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
         before: RunnableConfig | None = None,
         limit: int | None = None,
     ) -> AsyncIterator[CheckpointTuple]:
+        results = await self._with_retry(
+            self._alist,
+            config,
+            filter=filter,
+            before=before,
+            limit=limit,
+        )
+        for result in results:
+            yield result
+
+    async def _alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> list[CheckpointTuple]:
         """List checkpoints from the database asynchronously.
 
         This method retrieves a list of checkpoint tuples from the MySQL database based
@@ -101,7 +126,7 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
             await cur.execute(query, args)
             values = await cur.fetchall()
             if not values:
-                return
+                return []
             for value in values:
                 value["checkpoint"] = json.loads(value["checkpoint"])
                 value["channel_values"] = deserialize_channel_values(
@@ -132,10 +157,12 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
                             value["checkpoint"],
                             value["channel_values"],
                         )
-            for value in values:
-                yield await self._load_checkpoint_tuple(value)
+            return [await self._load_checkpoint_tuple(value) for value in values]
 
     async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        return await self._with_retry(self._aget_tuple, config)
+
+    async def _aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database asynchronously.
 
         This method retrieves a checkpoint tuple from the MySQL database based on the
@@ -201,6 +228,21 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
             return await self._load_checkpoint_tuple(value)
 
     async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return await self._with_retry(
+            self._aput,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+        )
+
+    async def _aput(
         self,
         config: RunnableConfig,
         checkpoint: Checkpoint,
@@ -280,6 +322,21 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
         task_id: str,
         task_path: str = "",
     ) -> None:
+        return await self._with_retry(
+            self._aput_writes,
+            config,
+            writes,
+            task_id,
+            task_path,
+        )
+
+    async def _aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
         """Store intermediate writes linked to a checkpoint asynchronously.
 
         This method saves intermediate writes associated with a checkpoint to the database.
@@ -307,6 +364,9 @@ class BaseAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
             await cur.executemany(query, params)
 
     async def adelete_thread(self, thread_id: str) -> None:
+        return await self._with_retry(self._adelete_thread, thread_id)
+
+    async def _adelete_thread(self, thread_id: str) -> None:
         """Delete all checkpoints and writes associated with a thread ID.
         Args:
             thread_id: The thread ID to delete.

--- a/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/base.py
+++ b/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/base.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import random
-from collections.abc import Sequence
-from typing import Any, Optional, cast
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from contextlib import suppress
+from typing import Any, Optional, TypeVar, cast
 
 from langchain_core.runnables import RunnableConfig
 
@@ -19,6 +23,126 @@ from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import TASKS
 
 MetadataInput = Optional[dict[str, Any]]
+_T = TypeVar("_T")
+
+_DISCONNECT_ERROR_CODES = {2003, 2006, 2013}
+_DISCONNECT_ERROR_MARKERS = (
+    "server has gone away",
+    "lost connection",
+    "broken pipe",
+    "connection reset",
+    "connection refused",
+    "connection closed",
+    "already closed",
+    "not connected",
+    "network is unreachable",
+    "timed out",
+    "readexactly",
+)
+
+
+def _is_disconnect_error(exc: BaseException) -> bool:
+    if isinstance(
+        exc,
+        (
+            BrokenPipeError,
+            ConnectionResetError,
+            ConnectionAbortedError,
+            TimeoutError,
+        ),
+    ):
+        return True
+
+    exc_name = exc.__class__.__name__
+    if exc_name == "InterfaceError":
+        return True
+    if exc_name == "OperationalError":
+        code = exc.args[0] if exc.args else None
+        if code in _DISCONNECT_ERROR_CODES:
+            return True
+
+    text = str(exc).lower()
+    return any(marker in text for marker in _DISCONNECT_ERROR_MARKERS)
+
+
+class _SyncCheckpointRetryMixin:
+    retry_max_attempts: int = 3
+    retry_base_delay: float = 0.2
+    conn: Any
+
+    def _recover_connection(self) -> None:
+        ping = getattr(self.conn, "ping", None)
+        if not callable(ping):
+            return
+
+        ping(reconnect=True)
+
+    def _with_retry(
+        self,
+        operation: Callable[..., _T],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        for attempt in range(1, self.retry_max_attempts + 1):
+            try:
+                return operation(*args, **kwargs)
+            except Exception as exc:
+                if not _is_disconnect_error(exc):
+                    raise
+                if attempt >= self.retry_max_attempts:
+                    raise
+
+                # Recovery is opportunistic; the next operation retry remains
+                # responsible for surfacing the original connectivity failure.
+                with suppress(Exception):
+                    self._recover_connection()
+
+                delay = self.retry_base_delay * attempt
+                if delay > 0:
+                    time.sleep(delay)
+
+        raise RuntimeError("unreachable retry state")
+
+
+class _AsyncCheckpointRetryMixin:
+    retry_max_attempts: int = 3
+    retry_base_delay: float = 0.2
+    conn: Any
+
+    async def _recover_connection(self) -> None:
+        ping = getattr(self.conn, "ping", None)
+        if not callable(ping):
+            return
+
+        result = ping(reconnect=True)
+        if inspect.isawaitable(result):
+            await result
+
+    async def _with_retry(
+        self,
+        operation: Callable[..., Awaitable[_T]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _T:
+        for attempt in range(1, self.retry_max_attempts + 1):
+            try:
+                return await operation(*args, **kwargs)
+            except Exception as exc:
+                if not _is_disconnect_error(exc):
+                    raise
+                if attempt >= self.retry_max_attempts:
+                    raise
+
+                # Recovery is opportunistic; the next operation retry remains
+                # responsible for surfacing the original connectivity failure.
+                with suppress(Exception):
+                    await self._recover_connection()
+
+                delay = self.retry_base_delay * attempt
+                if delay > 0:
+                    await asyncio.sleep(delay)
+
+        raise RuntimeError("unreachable retry state")
 
 """
 To add a new migration, add a new string to the MIGRATIONS list.

--- a/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/shallow.py
+++ b/langgraph-checkpoint-oceanbase-plugin/langgraph/checkpoint/oceanbase/shallow.py
@@ -18,7 +18,11 @@ from langgraph.checkpoint.base import (
     get_checkpoint_metadata,
 )
 from langgraph.checkpoint.oceanbase import _ainternal, _internal
-from langgraph.checkpoint.oceanbase.base import BaseMySQLSaver
+from langgraph.checkpoint.oceanbase.base import (
+    BaseMySQLSaver,
+    _AsyncCheckpointRetryMixin,
+    _SyncCheckpointRetryMixin,
+)
 from langgraph.checkpoint.oceanbase.utils import (
     deserialize_channel_values,
     deserialize_pending_sends,
@@ -212,7 +216,11 @@ def _dump_blobs(
     ]
 
 
-class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R]):
+class BaseShallowSyncMySQLSaver(
+    _SyncCheckpointRetryMixin,
+    BaseMySQLSaver,
+    Generic[_internal.C, _internal.R],
+):
     """A checkpoint saver that uses MySQL to store checkpoints.
     This checkpointer ONLY stores the most recent checkpoint and does NOT retain any history.
     It is meant to be a light-weight drop-in replacement for the PostgresSaver that
@@ -295,6 +303,23 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
         before: RunnableConfig | None = None,
         limit: int | None = None,
     ) -> Iterator[CheckpointTuple]:
+        results = self._with_retry(
+            self._list,
+            config,
+            filter=filter,
+            before=before,
+            limit=limit,
+        )
+        yield from results
+
+    def _list(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> list[CheckpointTuple]:
         """List checkpoints from the database.
 
         This method retrieves a list of checkpoint tuples from the MySQL database based
@@ -305,6 +330,7 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
         query = self.SELECT_SQL + where
         if limit:
             query += f" LIMIT {limit}"
+        checkpoints = []
         with self._cursor() as cur:
             cur.execute(self.SELECT_SQL + where, args)
             values = cur.fetchall()
@@ -321,22 +347,28 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
                     if pending_sends
                     else [],
                 }
-                yield CheckpointTuple(
-                    config={
-                        "configurable": {
-                            "thread_id": value["thread_id"],
-                            "checkpoint_ns": value["checkpoint_ns"],
-                            "checkpoint_id": checkpoint["id"],
-                        }
-                    },
-                    checkpoint=checkpoint,
-                    metadata=self._load_metadata(value["metadata"]),
-                    pending_writes=self._load_writes(
-                        deserialize_pending_writes(value["pending_writes"])
-                    ),
+                checkpoints.append(
+                    CheckpointTuple(
+                        config={
+                            "configurable": {
+                                "thread_id": value["thread_id"],
+                                "checkpoint_ns": value["checkpoint_ns"],
+                                "checkpoint_id": checkpoint["id"],
+                            }
+                        },
+                        checkpoint=checkpoint,
+                        metadata=self._load_metadata(value["metadata"]),
+                        pending_writes=self._load_writes(
+                            deserialize_pending_writes(value["pending_writes"])
+                        ),
+                    )
                 )
+        return checkpoints
 
     def get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        return self._with_retry(self._get_tuple, config)
+
+    def _get_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database.
 
         This method retrieves a checkpoint tuple from the MySQL database based on the
@@ -409,6 +441,21 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
                 )
 
     def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return self._with_retry(
+            self._put,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+        )
+
+    def _put(
         self,
         config: RunnableConfig,
         checkpoint: Checkpoint,
@@ -493,6 +540,21 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
         task_id: str,
         task_path: str = "",
     ) -> None:
+        return self._with_retry(
+            self._put_writes,
+            config,
+            writes,
+            task_id,
+            task_path,
+        )
+
+    def _put_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
         """Store intermediate writes linked to a checkpoint.
 
         This method saves intermediate writes associated with a checkpoint to the MySQL database.
@@ -521,7 +583,11 @@ class BaseShallowSyncMySQLSaver(BaseMySQLSaver, Generic[_internal.C, _internal.R
             )
 
 
-class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainternal.R]):
+class BaseShallowAsyncMySQLSaver(
+    _AsyncCheckpointRetryMixin,
+    BaseMySQLSaver,
+    Generic[_ainternal.C, _ainternal.R],
+):
     """A checkpoint saver that uses MySQL to store checkpoints asynchronously.
     This checkpointer ONLY stores the most recent checkpoint and does NOT retain any history.
     It is meant to be a light-weight drop-in replacement for the async MySQL saver that
@@ -607,6 +673,24 @@ class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainterna
         before: RunnableConfig | None = None,
         limit: int | None = None,
     ) -> AsyncIterator[CheckpointTuple]:
+        results = await self._with_retry(
+            self._alist,
+            config,
+            filter=filter,
+            before=before,
+            limit=limit,
+        )
+        for result in results:
+            yield result
+
+    async def _alist(
+        self,
+        config: RunnableConfig | None,
+        *,
+        filter: dict[str, Any] | None = None,
+        before: RunnableConfig | None = None,
+        limit: int | None = None,
+    ) -> list[CheckpointTuple]:
         """List checkpoints from the database asynchronously.
         This method retrieves a list of checkpoint tuples from the MySQL database based
         on the provided config. For shallow savers, this method returns a list with
@@ -616,6 +700,7 @@ class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainterna
         query = self.SELECT_SQL + where
         if limit:
             query += f" LIMIT {limit}"
+        checkpoints = []
         async with self._cursor() as cur:
             await cur.execute(self.SELECT_SQL + where, args)
             async for value in cur:
@@ -631,23 +716,29 @@ class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainterna
                     if pending_sends
                     else [],
                 }
-                yield CheckpointTuple(
-                    config={
-                        "configurable": {
-                            "thread_id": value["thread_id"],
-                            "checkpoint_ns": value["checkpoint_ns"],
-                            "checkpoint_id": checkpoint["id"],
-                        }
-                    },
-                    checkpoint=checkpoint,
-                    metadata=self._load_metadata(value["metadata"]),
-                    pending_writes=await asyncio.to_thread(
-                        self._load_writes,
-                        deserialize_pending_writes(value["pending_writes"]),
+                checkpoints.append(
+                    CheckpointTuple(
+                        config={
+                            "configurable": {
+                                "thread_id": value["thread_id"],
+                                "checkpoint_ns": value["checkpoint_ns"],
+                                "checkpoint_id": checkpoint["id"],
+                            }
+                        },
+                        checkpoint=checkpoint,
+                        metadata=self._load_metadata(value["metadata"]),
+                        pending_writes=await asyncio.to_thread(
+                            self._load_writes,
+                            deserialize_pending_writes(value["pending_writes"]),
+                        ),
                     ),
                 )
+        return checkpoints
 
     async def aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
+        return await self._with_retry(self._aget_tuple, config)
+
+    async def _aget_tuple(self, config: RunnableConfig) -> CheckpointTuple | None:
         """Get a checkpoint tuple from the database asynchronously.
         This method retrieves a checkpoint tuple from the MySQL database based on the
         provided config (matching the thread ID in the config).
@@ -697,6 +788,21 @@ class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainterna
                 )
 
     async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        return await self._with_retry(
+            self._aput,
+            config,
+            checkpoint,
+            metadata,
+            new_versions,
+        )
+
+    async def _aput(
         self,
         config: RunnableConfig,
         checkpoint: Checkpoint,
@@ -762,6 +868,21 @@ class BaseShallowAsyncMySQLSaver(BaseMySQLSaver, Generic[_ainternal.C, _ainterna
         return next_config
 
     async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Sequence[tuple[str, Any]],
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        return await self._with_retry(
+            self._aput_writes,
+            config,
+            writes,
+            task_id,
+            task_path,
+        )
+
+    async def _aput_writes(
         self,
         config: RunnableConfig,
         writes: Sequence[tuple[str, Any]],

--- a/langgraph-checkpoint-oceanbase-plugin/pyproject.toml
+++ b/langgraph-checkpoint-oceanbase-plugin/pyproject.toml
@@ -58,6 +58,9 @@ include = ["langgraph"]
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --strict-config --durations=5 -vv"
+markers = [
+  "no_db: mark tests that do not require a running MySQL/OceanBase database",
+]
 
 [tool.ruff]
 lint.select = [

--- a/langgraph-checkpoint-oceanbase-plugin/tests/conftest.py
+++ b/langgraph-checkpoint-oceanbase-plugin/tests/conftest.py
@@ -30,8 +30,12 @@ async def conn(anyio_backend: str) -> AsyncIterator[aiomysql.Connection]:
 
 
 @pytest.fixture(scope="function", autouse=True)
-async def clear_test_db(conn: aiomysql.Connection) -> None:
+async def clear_test_db(request: pytest.FixtureRequest) -> None:
     """Delete all tables before each test."""
+    if request.node.get_closest_marker("no_db"):
+        return
+
+    conn: aiomysql.Connection = request.getfixturevalue("conn")
     try:
         async with conn.cursor() as cursor:
             await cursor.execute("DELETE FROM checkpoints")

--- a/langgraph-checkpoint-oceanbase-plugin/tests/test_async.py
+++ b/langgraph-checkpoint-oceanbase-plugin/tests/test_async.py
@@ -42,8 +42,148 @@ SAVERS = [
 NON_SHALLOW_SAVERS = [saver for saver in SAVERS if "shallow" not in saver]
 
 
+class _RetryableOperationalError(Exception):
+    pass
+
+
+_RetryableOperationalError.__name__ = "OperationalError"
+
+
+class _NonRetryableOperationalError(Exception):
+    pass
+
+
+_NonRetryableOperationalError.__name__ = "OperationalError"
+
+
+class _RetryHarnessConnection:
+    def __init__(self) -> None:
+        self.pings = 0
+
+    async def ping(self, reconnect: bool = True) -> None:
+        assert reconnect is True
+        self.pings += 1
+
+
+class _RetryHarnessSaver(BaseAsyncMySQLSaver):
+    retry_base_delay = 0
+
+    @staticmethod
+    def _get_cursor_from_connection(conn: Any) -> Any:
+        raise NotImplementedError
+
+
+class _ShallowRetryHarnessSaver(BaseShallowAsyncMySQLSaver):
+    retry_base_delay = 0
+
+    @staticmethod
+    def _get_cursor_from_connection(conn: Any) -> Any:
+        raise NotImplementedError
+
+
 def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
+
+
+@pytest.mark.no_db
+async def test_async_saver_retries_aput_after_disconnect() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    async def flaky_aput(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2006, "server has gone away")
+        return {"configurable": {"thread_id": "thread-1", "checkpoint_id": "1"}}
+
+    setattr(saver, "_aput", flaky_aput)
+
+    result = await saver.aput(
+        {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+        empty_checkpoint(),
+        {},
+        {},
+    )
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert result["configurable"]["checkpoint_id"] == "1"
+
+
+@pytest.mark.no_db
+async def test_async_saver_does_not_retry_non_disconnect_errors() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    async def failing_aput(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        raise _NonRetryableOperationalError(1064, "syntax error")
+
+    setattr(saver, "_aput", failing_aput)
+
+    with pytest.raises(_NonRetryableOperationalError):
+        await saver.aput(
+            {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+            empty_checkpoint(),
+            {},
+            {},
+        )
+
+    assert calls == 1
+    assert conn.pings == 0
+
+
+@pytest.mark.no_db
+async def test_async_saver_retries_alist_full_operation() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    async def flaky_alist(*args: Any, **kwargs: Any) -> list[Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2013, "lost connection")
+        return ["checkpoint"]
+
+    setattr(saver, "_alist", flaky_alist)
+
+    results = [item async for item in saver.alist(None)]
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert results == ["checkpoint"]
+
+
+@pytest.mark.no_db
+async def test_shallow_async_saver_retries_aput_after_disconnect() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _ShallowRetryHarnessSaver(conn)
+    calls = 0
+
+    async def flaky_aput(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2006, "server has gone away")
+        return {"configurable": {"thread_id": "thread-1", "checkpoint_id": "1"}}
+
+    setattr(saver, "_aput", flaky_aput)
+
+    result = await saver.aput(
+        {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+        empty_checkpoint(),
+        {},
+        {},
+    )
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert result["configurable"]["checkpoint_id"] == "1"
 
 
 @asynccontextmanager

--- a/langgraph-checkpoint-oceanbase-plugin/tests/test_sync.py
+++ b/langgraph-checkpoint-oceanbase-plugin/tests/test_sync.py
@@ -19,7 +19,9 @@ from langgraph.checkpoint.base import (
     create_checkpoint,
     empty_checkpoint,
 )
+from langgraph.checkpoint.oceanbase import BaseSyncMySQLSaver
 from langgraph.checkpoint.oceanbase.pyoceanbase import PyOceanBaseSaver, ShallowPyMySQLSaver
+from langgraph.checkpoint.oceanbase.shallow import BaseShallowSyncMySQLSaver
 from langgraph.checkpoint.serde.types import TASKS
 from tests.conftest import (
     DEFAULT_BASE_URI,
@@ -39,8 +41,148 @@ SAVERS = [
 NON_SHALLOW_SAVERS = [saver for saver in SAVERS if saver != "shallow"]
 
 
+class _RetryableOperationalError(Exception):
+    pass
+
+
+_RetryableOperationalError.__name__ = "OperationalError"
+
+
+class _NonRetryableOperationalError(Exception):
+    pass
+
+
+_NonRetryableOperationalError.__name__ = "OperationalError"
+
+
+class _RetryHarnessConnection:
+    def __init__(self) -> None:
+        self.pings = 0
+
+    def ping(self, reconnect: bool = True) -> None:
+        assert reconnect is True
+        self.pings += 1
+
+
+class _RetryHarnessSaver(BaseSyncMySQLSaver):
+    retry_base_delay = 0
+
+    @staticmethod
+    def _get_cursor_from_connection(conn: Any) -> Any:
+        raise NotImplementedError
+
+
+class _ShallowRetryHarnessSaver(BaseShallowSyncMySQLSaver):
+    retry_base_delay = 0
+
+    @staticmethod
+    def _get_cursor_from_connection(conn: Any) -> Any:
+        raise NotImplementedError
+
+
 def _exclude_keys(config: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in config.items() if k not in EXCLUDED_METADATA_KEYS}
+
+
+@pytest.mark.no_db
+async def test_sync_saver_retries_put_after_disconnect() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    def flaky_put(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2006, "server has gone away")
+        return {"configurable": {"thread_id": "thread-1", "checkpoint_id": "1"}}
+
+    setattr(saver, "_put", flaky_put)
+
+    result = saver.put(
+        {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+        empty_checkpoint(),
+        {},
+        {},
+    )
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert result["configurable"]["checkpoint_id"] == "1"
+
+
+@pytest.mark.no_db
+async def test_sync_saver_does_not_retry_non_disconnect_errors() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    def failing_put(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        raise _NonRetryableOperationalError(1064, "syntax error")
+
+    setattr(saver, "_put", failing_put)
+
+    with pytest.raises(_NonRetryableOperationalError):
+        saver.put(
+            {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+            empty_checkpoint(),
+            {},
+            {},
+        )
+
+    assert calls == 1
+    assert conn.pings == 0
+
+
+@pytest.mark.no_db
+async def test_sync_saver_retries_list_full_operation() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _RetryHarnessSaver(conn)
+    calls = 0
+
+    def flaky_list(*args: Any, **kwargs: Any) -> list[Any]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2013, "lost connection")
+        return ["checkpoint"]
+
+    setattr(saver, "_list", flaky_list)
+
+    results = list(saver.list(None))
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert results == ["checkpoint"]
+
+
+@pytest.mark.no_db
+async def test_shallow_sync_saver_retries_put_after_disconnect() -> None:
+    conn = _RetryHarnessConnection()
+    saver = _ShallowRetryHarnessSaver(conn)
+    calls = 0
+
+    def flaky_put(*args: Any, **kwargs: Any) -> RunnableConfig:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _RetryableOperationalError(2006, "server has gone away")
+        return {"configurable": {"thread_id": "thread-1", "checkpoint_id": "1"}}
+
+    setattr(saver, "_put", flaky_put)
+
+    result = saver.put(
+        {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}},
+        empty_checkpoint(),
+        {},
+        {},
+    )
+
+    assert calls == 2
+    assert conn.pings == 1
+    assert result["configurable"]["checkpoint_id"] == "1"
 
 
 @contextmanager


### PR DESCRIPTION
## Summary

Add narrowly scoped retries for transient OceanBase/MySQL disconnects around runtime checkpoint operations.

This change retries only operation-level checkpoint reads/writes after disconnect-like failures. It does not retry `setup()` or migrations.

## Problem

The async and sync checkpoint savers currently execute runtime checkpoint operations directly inside `_cursor()`. `_cursor()` only wraps transaction begin/commit/rollback. If the connection drops while writing checkpoint state, the exception is propagated and the failed operation is not replayed.

That leaves a persistence gap: a caller may have already produced/streamed assistant or tool output, while the checkpoint state for that turn was not stored. The next turn can then load an older checkpoint and appear to lose the previous turn's assistant/tool messages while user input stored elsewhere still exists.

Driver or pool reconnection alone does not replay the failed SQL operation.

## Change

- Add shared transient disconnect detection for common MySQL/OceanBase connection failures.
- Add reusable operation-level retry wrappers to the sync, async, shallow sync,
  and shallow async checkpoint savers.
- Retry runtime checkpoint operations only:
  - sync: `list`, `get_tuple`, `put`, `put_writes`, `delete_thread`
  - async: `alist`, `aget_tuple`, `aput`, `aput_writes`, `adelete_thread`
  - shallow sync: `list`, `get_tuple`, `put`, `put_writes`
  - shallow async: `alist`, `aget_tuple`, `aput`, `aput_writes`
- Attempt `ping(reconnect=True)` for direct connections before retrying.
- Keep pool behavior simple: retrying the operation reacquires from the pool.
- Preserve non-transient error behavior: non-disconnect errors are still raised immediately.
- Keep `setup()`/migration execution unchanged.

## Why Operation-Level Retry

Retrying at cursor acquisition is not sufficient because disconnects can occur after part of an operation has started. The saver needs to replay the whole checkpoint operation, not just obtain a new cursor.

The runtime checkpoint write SQL is already idempotent or duplicate-tolerant:

- checkpoint blobs use `INSERT IGNORE`
- checkpoints use `ON DUPLICATE KEY UPDATE`
- checkpoint writes use `ON DUPLICATE KEY UPDATE` or `INSERT IGNORE`
- deletes are naturally idempotent
- reads are safe to retry

`setup()` is intentionally excluded because migrations are not guaranteed to be replay-safe.

## Tests

Added no-DB unit tests that simulate transient and non-transient failures without requiring a running OceanBase/MySQL service:

- async write retry after disconnect
- async non-disconnect errors are not retried
- async list retries the full operation
- shallow async write retry after disconnect
- sync write retry after disconnect
- sync non-disconnect errors are not retried
- sync list retries the full operation
- shallow sync write retry after disconnect

Validation run locally:

```bash
python -m py_compile langgraph/checkpoint/oceanbase/base.py langgraph/checkpoint/oceanbase/__init__.py langgraph/checkpoint/oceanbase/aio_base.py langgraph/checkpoint/oceanbase/shallow.py tests/test_async.py tests/test_sync.py tests/conftest.py
python -m pytest tests/test_async.py -m no_db tests/test_sync.py -m no_db
git diff --check
```
